### PR TITLE
fix: Fix incorrect call to client to produce inventory.

### DIFF
--- a/interfaces/v1/rootfs-image
+++ b/interfaces/v1/rootfs-image
@@ -96,7 +96,7 @@ case "$STATE" in
         ;;
 
     Inventory)
-        mender-update show-inventory
+        mender-update show-provides
         ;;
 
 esac


### PR DESCRIPTION
We use the Provides from the client to generate the inventory, so although it intuitively might look like it doesn't line up, calling `show-provides` from `Inventory` is correct in this instance.

Changelog: Title
Ticket: None